### PR TITLE
fix: 커스텀키보드 구매내역조회 response변경

### DIFF
--- a/src/main/java/site/keydeuk/store/domain/community/service/CommunityService.java
+++ b/src/main/java/site/keydeuk/store/domain/community/service/CommunityService.java
@@ -25,6 +25,7 @@ import site.keydeuk.store.domain.user.repository.UserRepository;
 import site.keydeuk.store.entity.*;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
 
@@ -51,9 +52,8 @@ public class CommunityService {
         //1. order userid로 조회
         List<Order> orders = orderService.getAllOrdersStatusConfirmedByUserId(userId);
 
-        if (orders.isEmpty()) throw new CustomException(ORDER_HISTORY_NOT_FOUND);
-        log.info("userId: {}",userId);
-        log.info("sixe :{}",orders.size());
+        if (orders.isEmpty()) return Collections.emptyList();
+
         List<OrderItem> orderItemList = new ArrayList<>();
         //2. order중 1000000번 이상인 것만 조회
         for(Order order : orders){


### PR DESCRIPTION
## 🚀 작업 내용

- 커스텀 키보드 구매내역 없을 시 빈배열로 반환

## 📝 참고 사항

-

## 🚨 관련 이슈 (이슈 번호)

- #

## ✅ 체크리스트

- [ ] Code Review 요청
- [ ] Label 설정
- [ ] PR 제목 규칙에 맞는지 확인
