### PR TITLE
fix: 커뮤니티 글 작성 오류 수정

### DIFF
--- a/src/main/java/site/keydeuk/store/domain/community/service/CommunityService.java
+++ b/src/main/java/site/keydeuk/store/domain/community/service/CommunityService.java
@@ -177,6 +177,8 @@ public class CommunityService {
                 .viewCount(0)
                 .customOptionId(postDto.getProductId())
                 .build();
+
+        community.setUpdatedAt(LocalDateTime.now());
         communityRepository.save(community);
 
         for (MultipartFile file: files){
@@ -185,6 +187,7 @@ public class CommunityService {
                     .community(community)
                     .imgUrl(imgUrl)
                     .build();
+
         communityImgRepository.save(communityImg);
         }
         return community.getId();

--- a/src/main/java/site/keydeuk/store/entity/Community.java
+++ b/src/main/java/site/keydeuk/store/entity/Community.java
@@ -7,10 +7,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
-import org.springframework.data.annotation.LastModifiedDate;
-
 import java.time.LocalDateTime;
 import java.util.List;
+
 
 @Getter
 @Builder
@@ -39,7 +38,6 @@ public class Community {
     @CreationTimestamp
     private LocalDateTime createdAt;
 
-    @LastModifiedDate
     private LocalDateTime updatedAt;
 
     @OneToMany(mappedBy = "community")


### PR DESCRIPTION
## 🚀 작업 내용

-커뮤니티 글 작성 시 updateAt 컬럼이 null이 허용되지 않는데, createCommunity메소드 호출 시 null 값이 삽입되어 오류 발생

## 📝 참고 사항

-

## 🚨 관련 이슈 (이슈 번호)

- #258

## ✅ 체크리스트

- [ ] Code Review 요청
- [ ] Label 설정
- [ ] PR 제목 규칙에 맞는지 확인
