### PR TITLE
feat : 상품 상세보기 cache 처리 및 조회수 배치 저장

### DIFF
--- a/src/main/java/site/keydeuk/store/StoreApplication.java
+++ b/src/main/java/site/keydeuk/store/StoreApplication.java
@@ -3,9 +3,11 @@ package site.keydeuk.store;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class StoreApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/site/keydeuk/store/common/redis/service/RedisService.java
+++ b/src/main/java/site/keydeuk/store/common/redis/service/RedisService.java
@@ -15,4 +15,8 @@ public interface RedisService {
     boolean setIfAbsent(String key, Object value, Long expiredTime);
 
     boolean delete(String key);
+
+   void addToSortedSet(String prefixKey, String key);
+
+    void checkSizeAndRemoveKey(String prefixKey, int size);
 }

--- a/src/main/java/site/keydeuk/store/common/redis/service/RedisServiceImpl.java
+++ b/src/main/java/site/keydeuk/store/common/redis/service/RedisServiceImpl.java
@@ -76,4 +76,30 @@ public class RedisServiceImpl implements RedisService {
         log.info("Delete Redis Key = [{}]", key);
         return Boolean.TRUE.equals(redisTemplate.delete(key));
     }
+
+    @Override
+    public void addToSortedSet(String prefixKey, String key){
+        log.info("[확인]: prefix {}, key {}", prefixKey,key);
+        long now = System.currentTimeMillis();
+        redisTemplate.opsForZSet().add(prefixKey,key,now);
+    }
+
+    @Override
+    public void checkSizeAndRemoveKey(String prefixKey, int size){
+        Long currentSize = redisTemplate.opsForZSet().size(prefixKey);
+
+        log.info("[확인]: prefix {}, size {}, current:{}", prefixKey,size,currentSize);
+
+
+        if (currentSize!= null && currentSize > size){
+            // 오래된 키 삭제
+            String oldestKey = redisTemplate.opsForZSet().range(prefixKey,0,0)
+                .stream().findFirst().orElse(null);
+            if (oldestKey!= null){
+                redisTemplate.opsForZSet().remove(prefixKey, oldestKey);
+                delete(oldestKey);
+            }
+
+        }
+    }
 }

--- a/src/main/java/site/keydeuk/store/common/redis/service/RedisServiceImpl.java
+++ b/src/main/java/site/keydeuk/store/common/redis/service/RedisServiceImpl.java
@@ -79,7 +79,6 @@ public class RedisServiceImpl implements RedisService {
 
     @Override
     public void addToSortedSet(String prefixKey, String key){
-        log.info("[확인]: prefix {}, key {}", prefixKey,key);
         long now = System.currentTimeMillis();
         redisTemplate.opsForZSet().add(prefixKey,key,now);
     }
@@ -87,9 +86,6 @@ public class RedisServiceImpl implements RedisService {
     @Override
     public void checkSizeAndRemoveKey(String prefixKey, int size){
         Long currentSize = redisTemplate.opsForZSet().size(prefixKey);
-
-        log.info("[확인]: prefix {}, size {}, current:{}", prefixKey,size,currentSize);
-
 
         if (currentSize!= null && currentSize > size){
             // 오래된 키 삭제

--- a/src/main/java/site/keydeuk/store/common/scheduler/ProductScheduler.java
+++ b/src/main/java/site/keydeuk/store/common/scheduler/ProductScheduler.java
@@ -1,0 +1,18 @@
+package site.keydeuk.store.common.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import site.keydeuk.store.domain.product.service.ProductService;
+
+@Component
+@RequiredArgsConstructor
+public class ProductScheduler {
+
+    private final ProductService productService;
+
+    @Scheduled(fixedDelay= 86400000) //24시간
+    public void schedularFixedDelayTask(){
+        productService.saveViewCount();
+    }
+}

--- a/src/main/java/site/keydeuk/store/domain/product/dto/productdetail/ProductDetailResponseDto.java
+++ b/src/main/java/site/keydeuk/store/domain/product/dto/productdetail/ProductDetailResponseDto.java
@@ -1,6 +1,7 @@
 package site.keydeuk.store.domain.product.dto.productdetail;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import site.keydeuk.store.domain.productswitchoption.dto.ProductSwitchOptionDto;
 import site.keydeuk.store.entity.Product;
@@ -10,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Setter
+@NoArgsConstructor
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class ProductDetailResponseDto {
 

--- a/src/main/java/site/keydeuk/store/domain/product/service/ProductService.java
+++ b/src/main/java/site/keydeuk/store/domain/product/service/ProductService.java
@@ -5,12 +5,15 @@ import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.*;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
+import site.keydeuk.store.common.redis.service.RedisService;
 import site.keydeuk.store.domain.customoption.dto.OptionProductsResponseDto;
 import site.keydeuk.store.domain.likes.service.LikesService;
 import site.keydeuk.store.domain.product.dto.productdetail.ProductDetailResponseDto;
@@ -31,18 +34,42 @@ public class ProductService {
     private final ProductRepository productRepository;
     private final LikesService likesService;
     private final ReviewService reviewService;
+    private final RedisService redisService;
+    private static final int MAX_CACHE_PRODUCT = 5;
+    private static final long PRODUCT_EXPIRE_DAY = 604800;
+    public static final String PRODUCT_KEY_PREFIX = "cache:product:";
 
     /** 상품 상세 조회 */
     public ProductDetailResponseDto getProductDetailById(Integer productId){
 
-        Product product = getProductById(productId);
+        // 캐시에서 데이터 조회
+        String key = PRODUCT_KEY_PREFIX+productId;
+        Optional<ProductDetailResponseDto> optionalCacheDto = redisService.get(key, ProductDetailResponseDto.class);
 
-        // 조회수 증가
-        product.setViews(product.getViews()+1);
-        productRepository.save(product);
-        Long reviewCount = reviewService.countByProductId(productId);
-        Double scope = reviewService.getAverageScoreByProductId(productId);
-        return new ProductDetailResponseDto(product,reviewCount,scope);
+        if (optionalCacheDto.isPresent()) {// cacheDto가 null이 아닐 때의 로직
+            log.info("[info]: cache hit! productId: {}",key);
+            return optionalCacheDto.get();
+
+        } else {
+            // cacheDto가 null일 때의 로직
+            Product product = getProductById(productId);
+
+            // 조회수 증가
+            product.setViews(product.getViews()+1);
+            productRepository.save(product);
+            Long reviewCount = reviewService.countByProductId(productId);
+            Double scope = reviewService.getAverageScoreByProductId(productId);
+            ProductDetailResponseDto responseDto = new ProductDetailResponseDto(product,reviewCount,scope);
+
+            //캐시 저장, Sorted Set에 키 추가
+            redisService.set(key, responseDto,PRODUCT_EXPIRE_DAY);
+            redisService.addToSortedSet(PRODUCT_KEY_PREFIX,key);
+
+            //200개 넘으면 오래된 것 순으로 삭제
+            redisService.checkSizeAndRemoveKey(PRODUCT_KEY_PREFIX,MAX_CACHE_PRODUCT);
+            return responseDto;
+        }
+
     }
 
 


### PR DESCRIPTION
## 🚀 작업 내용

- 상품 상세보기 cache 처리
- 최대 200개 cache 저장
- 만료 기간 : 7일 
- 스케줄러를 통해 조회 수 1시간 마다 저장
- 조회 수 저장 시 cache 삭제

## 📝 참고 사항

## 🚨 관련 이슈 (이슈 번호)

- #260 

## ✅ 체크리스트

- [ ] Code Review 요청
- [ ] Label 설정
- [ ] PR 제목 규칙에 맞는지 확인
